### PR TITLE
security: fix XSS vectors and error info leak

### DIFF
--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -1,7 +1,7 @@
 /**
  * SearchResults Component
  *
- * Displays search results with highlighting and metadata
+ * Displays search results with metadata
  */
 
 interface SearchResult {
@@ -9,7 +9,6 @@ interface SearchResult {
   type: 'course' | 'lesson' | 'discussion' | 'forum';
   title: string;
   description: string;
-  highlight?: string;
   url: string;
   relevance: number;
   metadata: Record<string, any>;
@@ -102,17 +101,10 @@ export default function SearchResults({ results, query, total }: SearchResultsPr
             </a>
           </h3>
 
-          {/* Description with highlights */}
-          {result.highlight ? (
-            <div
-              className="text-gray-600 text-sm mb-3 line-clamp-2"
-              dangerouslySetInnerHTML={{ __html: result.highlight }}
-            />
-          ) : (
-            <p className="text-gray-600 text-sm mb-3 line-clamp-2">
-              {result.description}
-            </p>
-          )}
+          {/* Description */}
+          <p className="text-gray-600 text-sm mb-3 line-clamp-2">
+            {result.description}
+          </p>
 
           {/* Metadata */}
           <div className="flex flex-wrap gap-3 text-xs text-gray-500">

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -6,6 +6,12 @@
 type ToastType = 'success' | 'error' | 'warning' | 'info';
 
 const TOAST_CONTAINER_ID = 'c4c-toast-container';
+
+function escapeHtml(str: string): string {
+  const div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
+}
 const DEFAULT_DURATION = 5000;
 
 /**
@@ -91,7 +97,7 @@ export function showToast(
   toast.style.cssText = getToastStyles(type);
   toast.innerHTML = `
     <span style="font-size: 18px;">${getToastIcon(type)}</span>
-    <span style="flex: 1;">${message}</span>
+    <span style="flex: 1;">${escapeHtml(message)}</span>
     <button onclick="this.parentElement.remove()" style="
       background: none;
       border: none;
@@ -167,7 +173,7 @@ export function showConfirm(
         width: 90%;
         box-shadow: 0 20px 40px rgba(0,0,0,0.2);
       ">
-        <p style="margin: 0 0 20px; font-size: 16px; color: #1f2937;">${message}</p>
+        <p style="margin: 0 0 20px; font-size: 16px; color: #1f2937;">${escapeHtml(message)}</p>
         <div style="display: flex; gap: 12px; justify-content: flex-end;">
           <button id="confirm-cancel" style="
             padding: 10px 20px;
@@ -176,7 +182,7 @@ export function showConfirm(
             border-radius: 6px;
             cursor: pointer;
             font-size: 14px;
-          ">${cancelText}</button>
+          ">${escapeHtml(cancelText)}</button>
           <button id="confirm-ok" style="
             padding: 10px 20px;
             border: none;
@@ -185,7 +191,7 @@ export function showConfirm(
             border-radius: 6px;
             cursor: pointer;
             font-size: 14px;
-          ">${confirmText}</button>
+          ">${escapeHtml(confirmText)}</button>
         </div>
       </div>
     `;
@@ -235,7 +241,7 @@ export function setButtonLoading(
           border-radius: 50%;
           animation: spin 0.75s linear infinite;
         "></span>
-        ${loadingText}
+        ${escapeHtml(loadingText)}
       </span>
     `;
   } else {
@@ -275,7 +281,7 @@ export function showLoading(message: string = 'Loading...'): string {
       border-radius: 50%;
       animation: spin 1s linear infinite;
     "></div>
-    <p style="margin-top: 16px; color: #4b5563; font-size: 16px;">${message}</p>
+    <p style="margin-top: 16px; color: #4b5563; font-size: 16px;">${escapeHtml(message)}</p>
   `;
 
   document.body.appendChild(overlay);

--- a/src/pages/api/teacher/enroll-student.ts
+++ b/src/pages/api/teacher/enroll-student.ts
@@ -172,7 +172,6 @@ export const POST: APIRoute = async ({ request }) => {
     console.error('[enroll-student] Error:', error);
     return new Response(JSON.stringify({
       error: 'Internal server error',
-      details: error instanceof Error ? error.message : 'Unknown error'
     }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' }


### PR DESCRIPTION
## Summary

- **SearchResults.tsx**: Removed `dangerouslySetInnerHTML` with unsanitized `highlight` field. The highlight feature isn't wired up yet, and when it is, it needs proper sanitization (DOMPurify or server-side). For now, falls back to safe React text rendering via `{result.description}`.
- **notifications.ts**: All `innerHTML` interpolations (`message`, `confirmText`, `cancelText`, `loadingText`) now go through `escapeHtml()` which uses `textContent`-based encoding. Prevents XSS if notification messages ever include user-controlled data.
- **enroll-student.ts**: Removed `details` field from 500 error response that was leaking internal `error.message` to the client.

## Context

Findings from stuckvgn AI reviewer audit. The enroll-student auth concern (unauthenticated access) was already fixed in a previous commit — endpoint has proper JWT + teacher role + course ownership checks. The XSS patterns were not actively exploitable today (all innerHTML inputs are currently hardcoded strings, highlight field is unpopulated) but were unsafe patterns waiting to become vulnerabilities.

## Test plan

- [ ] Toast notifications still render correctly
- [ ] Confirmation dialogs still work
- [ ] Search results display descriptions properly
- [ ] Enroll-student API still returns proper error responses (without internal details)

🤖 Generated with [Claude Code](https://claude.com/claude-code)