### PR TITLE
fix(react): add React default import to all JSX components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "@types/sanitize-html": "^2.16.1",
         "@vitejs/plugin-react": "^5.1.4",
         "axe-core": "^4.11.3",
@@ -4341,6 +4342,16 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/react-grid-layout": {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@types/sanitize-html": "^2.16.1",
     "@vitejs/plugin-react": "^5.1.4",
     "axe-core": "^4.11.3",

--- a/src/components/CohortStats.tsx
+++ b/src/components/CohortStats.tsx
@@ -9,6 +9,7 @@
  * - Struggling students count
  */
 
+import React from 'react';
 import type { CohortAnalytics } from '../types';
 
 interface CohortStatsProps {

--- a/src/components/EmailComposeModal.tsx
+++ b/src/components/EmailComposeModal.tsx
@@ -4,7 +4,7 @@
  * Supports sending to selected students or all enrolled students in a cohort.
  */
 
-import { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
 interface Recipient {

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -9,7 +9,7 @@
  * - Last activity
  */
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 import type { LeaderboardEntry } from '../types';
 
 interface LeaderboardProps {

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -6,7 +6,7 @@
  * Real-time updates via Supabase subscriptions
  */
 
-import { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { supabase } from '@/lib/supabase';
 import type { Notification } from '../types/messaging';
 

--- a/src/components/ProgressChart.tsx
+++ b/src/components/ProgressChart.tsx
@@ -8,6 +8,7 @@
  * - Average completion rate
  */
 
+import React from 'react';
 import {
   Chart as ChartJS,
   CategoryScale,

--- a/src/components/QuizCard.tsx
+++ b/src/components/QuizCard.tsx
@@ -4,7 +4,7 @@
  * Displays quiz information in lesson context with start/continue/review options
  */
 
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import type { QuizWithDetails, QuizAttempt } from '@/types/quiz';
 
 interface QuizCardProps {

--- a/src/components/QuizProgress.tsx
+++ b/src/components/QuizProgress.tsx
@@ -4,7 +4,7 @@
  * Shows quiz progress with question counter and progress bar
  */
 
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 interface QuizProgressProps {
   currentQuestion: number;

--- a/src/components/QuizQuestion.tsx
+++ b/src/components/QuizQuestion.tsx
@@ -5,7 +5,7 @@
  * Supports: multiple choice, true/false, short answer, essay, fill in blank
  */
 
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import type { QuizQuestionForStudent } from '@/types/quiz';
 
 interface QuizQuestionProps {

--- a/src/components/QuizResults.tsx
+++ b/src/components/QuizResults.tsx
@@ -4,6 +4,7 @@
  * Displays quiz results with score, feedback, and review options
  */
 
+import React from 'react';
 import type { Quiz, QuizAttempt } from '@/types/quiz';
 
 interface QuizResultsProps {

--- a/src/components/QuizTimer.tsx
+++ b/src/components/QuizTimer.tsx
@@ -4,7 +4,7 @@
  * Countdown timer for timed quizzes with visual warnings
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 
 interface QuizTimerProps {
   startedAt: string;

--- a/src/components/StrugglingStudents.tsx
+++ b/src/components/StrugglingStudents.tsx
@@ -8,7 +8,7 @@
  * Provides quick actions to reach out to students
  */
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 import type { StudentWithProgress } from '../types';
 import EmailComposeModal from './EmailComposeModal';
 

--- a/src/components/analytics/D3HeatMap.tsx
+++ b/src/components/analytics/D3HeatMap.tsx
@@ -7,7 +7,7 @@
  */
 
 import * as d3 from 'd3';
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 interface HeatMapCell {
   day: number;      // 0-6 (Sunday-Saturday)

--- a/src/components/analytics/DateRangeSelector.tsx
+++ b/src/components/analytics/DateRangeSelector.tsx
@@ -5,7 +5,7 @@
  * Flexible date range selection with presets and custom range picker
  */
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 
 export interface DateRange {
   start: Date;

--- a/src/components/analytics/ExportPanel.tsx
+++ b/src/components/analytics/ExportPanel.tsx
@@ -5,7 +5,7 @@
  * Export analytics data in multiple formats (CSV, PDF, Excel, PNG)
  */
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 import * as XLSX from 'exceljs';
 import Papa from 'papaparse';
 import jsPDF from 'jspdf';

--- a/src/components/analytics/MetricCard.tsx
+++ b/src/components/analytics/MetricCard.tsx
@@ -5,7 +5,7 @@
  * Display key metrics with trend indicators and comparison data
  */
 
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface Props {
   title: string;

--- a/src/components/certificates/CertificateCard.tsx
+++ b/src/components/certificates/CertificateCard.tsx
@@ -3,7 +3,7 @@
  * Displays a certificate with download and verification options
  */
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 
 // Certificate type matching schema.sql certificates table
 interface Certificate {

--- a/src/components/search/NoResults.tsx
+++ b/src/components/search/NoResults.tsx
@@ -4,6 +4,8 @@
  * Zero-results state with "Did you mean?" suggestions
  */
 
+import React from 'react';
+
 interface NoResultsProps {
   query: string;
   suggestions?: string[];

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -8,7 +8,7 @@
  * - Mobile responsive
  */
 
-import { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import SearchSuggestions from './SearchSuggestions';
 
 interface SearchBarProps {

--- a/src/components/search/SearchFilters.tsx
+++ b/src/components/search/SearchFilters.tsx
@@ -4,6 +4,8 @@
  * Filter sidebar for search results
  */
 
+import React from 'react';
+
 interface SearchFiltersProps {
   filters: {
     track?: string;

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -4,6 +4,8 @@
  * Displays search results with metadata
  */
 
+import React from 'react';
+
 interface SearchResult {
   id: number;
   type: 'course' | 'lesson' | 'discussion' | 'forum';

--- a/src/components/search/SearchSuggestions.tsx
+++ b/src/components/search/SearchSuggestions.tsx
@@ -4,6 +4,8 @@
  * Autocomplete dropdown for search suggestions
  */
 
+import React from 'react';
+
 interface SearchSuggestionsProps {
   suggestions: string[];
   onClick: (suggestion: string) => void;

--- a/src/components/student/AIKeyWidget.tsx
+++ b/src/components/student/AIKeyWidget.tsx
@@ -5,7 +5,7 @@
  * Shows a one-time key reveal modal, then a usage visualization.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { supabase } from '../../lib/supabase';
 
 type WidgetState = 'loading' | 'no_config' | 'provisioning' | 'ready' | 'error';

--- a/src/components/student/AssignmentCard.tsx
+++ b/src/components/student/AssignmentCard.tsx
@@ -3,7 +3,7 @@
  * Display assignment details and allow student submission
  */
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 import type { AssignmentWithSubmission } from '@/types/assignment';
 import { getAssignmentStatus, getBadgeClasses } from '@/lib/assignment-status';
 import FileUploader from './FileUploader';

--- a/src/components/student/AssignmentRubric.tsx
+++ b/src/components/student/AssignmentRubric.tsx
@@ -2,6 +2,7 @@
  * Assignment Rubric Component
  * Display grading rubric for an assignment
  */
+import React from 'react';
 
 interface RubricCriterion {
   name: string;

--- a/src/components/student/DueDateCountdown.tsx
+++ b/src/components/student/DueDateCountdown.tsx
@@ -2,9 +2,7 @@
  * Due Date Countdown Component
  * Display countdown timer to assignment due date
  */
-import React from 'react';
-
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 
 interface DueDateCountdownProps {
   dueDate: string;

--- a/src/components/student/DueDateCountdown.tsx
+++ b/src/components/student/DueDateCountdown.tsx
@@ -2,6 +2,7 @@
  * Due Date Countdown Component
  * Display countdown timer to assignment due date
  */
+import React from 'react';
 
 import { useState, useEffect } from 'react';
 

--- a/src/components/student/FileUploader.tsx
+++ b/src/components/student/FileUploader.tsx
@@ -2,9 +2,7 @@
  * File Uploader Component
  * Drag-and-drop file upload for assignment submissions
  */
-import React from 'react';
-
-import { useState, useRef } from 'react';
+import React, { useState, useRef } from 'react';
 import { validateFile, formatFileSize, getFileIcon } from '@/lib/file-upload';
 
 interface FileUploaderProps {

--- a/src/components/student/FileUploader.tsx
+++ b/src/components/student/FileUploader.tsx
@@ -2,6 +2,7 @@
  * File Uploader Component
  * Drag-and-drop file upload for assignment submissions
  */
+import React from 'react';
 
 import { useState, useRef } from 'react';
 import { validateFile, formatFileSize, getFileIcon } from '@/lib/file-upload';

--- a/src/components/student/SubmissionHistory.tsx
+++ b/src/components/student/SubmissionHistory.tsx
@@ -3,7 +3,7 @@
  * View all submissions and history for an assignment
  */
 
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { formatFileSize, getFileIcon } from '@/lib/file-upload';
 import type { Submission } from '@/types/assignment';
 

--- a/src/components/student/SubmissionStatus.tsx
+++ b/src/components/student/SubmissionStatus.tsx
@@ -2,6 +2,7 @@
  * Submission Status Component
  * Visual status indicator for assignment submissions
  */
+import React from 'react';
 
 import type { Submission } from '@/types/assignment';
 import type { AssignmentStatus } from '@/lib/assignment-status';

--- a/src/components/teacher/AssignmentCreator.tsx
+++ b/src/components/teacher/AssignmentCreator.tsx
@@ -3,7 +3,7 @@
  * Modal for creating and editing assignments
  */
 
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import type { Assignment } from '@/types/assignment';
 
 interface AssignmentCreatorProps {

--- a/src/components/teacher/AssignmentGrader.tsx
+++ b/src/components/teacher/AssignmentGrader.tsx
@@ -3,7 +3,7 @@
  * Grade individual student submissions
  */
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { formatFileSize, getFileIcon } from '@/lib/file-upload';
 
 interface AssignmentGraderProps {

--- a/src/components/teacher/SubmissionsList.tsx
+++ b/src/components/teacher/SubmissionsList.tsx
@@ -3,7 +3,7 @@
  * Shows all student submissions for an assignment
  */
 
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { formatFileSize, getFileIcon } from '@/lib/file-upload';
 import AssignmentGrader from './AssignmentGrader';
 


### PR DESCRIPTION
## Root cause

Astro's `<script>` block compilation path uses the **classic JSX transform** (`React.createElement`) rather than the automatic transform (`react/jsx-runtime`). Components imported inside `<script>` blocks needed `React` in scope at runtime, but had only named imports (`{ useState }`) or no React import at all.

At build time, Rollup sees `React.createElement(...)` as a free variable — it doesn't link it to the React module because nothing in the file imports `React` as a default. At runtime, the browser throws `ReferenceError: React is not defined`.

This was visible as a console crash on `/teacher/progress` (and would affect `/teacher/analytics`, `/assignments/[id]`, `/quizzes/[id]/*` too).

## Fix

Adds `import React from 'react'` to all 31 affected components — either as a new import or by extending existing named imports to include the default (`import React, { useState } from 'react'`). No logic changes.

## Scope

31 components across:
- `src/components/` (CohortStats, ProgressChart, StrugglingStudents, Leaderboard, EmailComposeModal, QuizCard/Question/Progress/Results/Timer, NotificationBell)
- `src/components/analytics/` (D3HeatMap, DateRangeSelector, MetricCard, ExportPanel)
- `src/components/certificates/` (CertificateCard)
- `src/components/search/` (SearchBar, SearchFilters, SearchResults, SearchSuggestions, NoResults)
- `src/components/student/` (AIKeyWidget, AssignmentCard, AssignmentRubric, DueDateCountdown, FileUploader, SubmissionHistory, SubmissionStatus)
- `src/components/teacher/` (AssignmentCreator, AssignmentGrader, SubmissionsList)

## Test plan

- [ ] Vercel preview build passes
- [ ] `/teacher/progress` loads without console errors
- [ ] `/teacher/analytics` loads without console errors
- [ ] No regressions on existing pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal refactoring across components to improve code organization and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->