### PR TITLE
fix(types): resolve 11 TypeScript errors in Schema-Types Sync check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "@types/sanitize-html": "^2.16.1",
         "@vitejs/plugin-react": "^5.1.4",
         "axe-core": "^4.11.3",
@@ -4341,6 +4342,16 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/react-grid-layout": {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@types/sanitize-html": "^2.16.1",
     "@vitejs/plugin-react": "^5.1.4",
     "axe-core": "^4.11.3",


### PR DESCRIPTION
## Summary

- All 11 errors in the Schema-Types Synchronization Check CI job are `ts(7016)` — missing type declaration for `react-dom` and `react-dom/client`
- Root cause: `@types/react-dom` was absent from `devDependencies` while `react-dom` itself is in `dependencies`
- Fix: add `@types/react-dom@^19.2.3` to `devDependencies` — confirmed `astro check` goes from 11 errors to 0

## Compatibility with PR #163

PR #163 adds the same `@types/react-dom` entry. This PR and #163 make an identical change to `package.json`. Whichever merges second will be a clean no-op on that line. Both will merge without conflict.

## Files changed

- `package.json` — added `"@types/react-dom": "^19.2.3"` to `devDependencies`
- `package-lock.json` — lockfile updated accordingly

## Test plan

- [x] `npx astro check` locally: **0 errors** (was 11)
- [x] Change is scoped strictly to the missing type package — no source files modified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to improve type safety and development experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->