### PR TITLE
docs: comprehensive README and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,30 @@
 
 ---
 
+## 0. Organizational Context and Current Status
+
+**Layer:** 1 | **Lever:** Strengthen | **Integration:** Standalone (links to platform)
+
+C4C Campus is the developer recruitment funnel for the [Open Paws](https://openpaws.ai) Layer 1 pipeline — the first thing prospective bootcamp and Guild developers see. It is critical for India community recruitment (Bengaluru + Mumbai launch, May 2026).
+
+**Last confirmed status (2026-04-09):**
+
+- **May 2026 deadline is hard.** The Resident Developer cohort launch is the primary driver of all priority decisions.
+- **LMS content for May cohort is unassigned — this is a blocker.** Nothing else about May launch matters if developers arrive and there is nothing to do.
+- **Graze-CLI is NOT in curriculum yet.** Do not add Graze-CLI references to this site until a smoke test on a non-core-team machine passes. Sam coordinates.
+- **No-animal-violence VS Code extension + pre-commit hook are NOT in curriculum yet.** Do not add these to the developer onboarding flow until a curriculum decision is made.
+- The platform at `open-paws-platform` is where enrolled developers actually work — this site is the recruitment funnel to it.
+
+**Fetch fresh strategy context each session:**
+
+```bash
+gh api repos/Open-Paws/open-paws-strategy/contents/org-overview.md --jq '.content' | base64 -d
+gh api repos/Open-Paws/open-paws-strategy/contents/priorities.md --jq '.content' | base64 -d
+gh api repos/Open-Paws/open-paws-strategy/contents/settled-decisions.md --jq '.content' | base64 -d
+```
+
+---
+
 ## 1. Critical Rules
 
 ### The Schema is Immutable
@@ -37,6 +61,8 @@ The site is predominantly working but contains bugs. When debugging or implement
 3. **Don't remove "unnecessary" null checks** — They're probably there for a reason
 4. **Don't change API response structures** — Existing clients depend on them
 5. **Don't modify shared utilities** without understanding all usages
+6. **Don't add Graze-CLI references** until the smoke test passes
+7. **Don't add no-animal-violence tooling to the dev onboarding flow** until curriculum decision is made
 
 ### Validation Commands
 
@@ -58,7 +84,7 @@ npm run test:integration      # Integration tests
 on animal advocacy, climate action, and AI safety education tracks.
 
 | Layer | Technology |
-|-------|-----------|
+|-------|-----------| 
 | Framework | Astro 5.x SSR (server-rendered, not static) |
 | Hosting | Vercel (serverless functions + edge) |
 | UI Islands | React 19 (`client:only="react"` or `client:load`) |
@@ -84,12 +110,15 @@ on animal advocacy, climate action, and AI safety education tracks.
 ```
 c4c_website/
 ├── AGENTS.md                  # This file — the complete agent reference
+├── CLAUDE.md                  # AI coding guidelines (overlaps this file; this file is authoritative)
 ├── schema.sql                 # IMMUTABLE database schema (source of truth)
 ├── astro.config.mjs           # Astro + Vercel SSR config
 ├── tailwind.config.mjs        # Tailwind v4 config
 ├── vitest.config.ts           # Unit test config (jsdom)
 ├── vitest.integration.config.ts # Integration test config (node, real DB)
 ├── playwright.config.ts       # E2E test config (6 browser/device combos)
+├── playwright.personas.yaml   # Persona definitions for QA testing
+├── vercel.json                # Security headers + cron job schedule
 ├── .env.example               # All environment variables documented
 ├── src/
 │   ├── middleware/             # Request pipeline (auth, security, caching)
@@ -125,6 +154,10 @@ c4c_website/
 │   │   ├── dashboard.astro    # Student dashboard
 │   │   ├── courses/           # Course browsing & detail pages
 │   │   ├── assignments/       # Assignment list & submission pages
+│   │   ├── apply.astro        # Application form (public, stores to Supabase)
+│   │   ├── programs.astro     # Programs overview (public recruitment funnel)
+│   │   ├── tracks.astro       # Focus track details (public)
+│   │   ├── framework.astro    # C4C framework page (public)
 │   │   └── ...
 │   ├── components/            # React components (islands)
 │   │   ├── student/           # Student-facing widgets
@@ -155,6 +188,7 @@ c4c_website/
 - `src/lib/auth.ts` — JWT verification, token extraction, role checks
 - `src/lib/api-handlers.ts` — API utility functions
 - `src/lib/time-gating.ts` — Cohort schedule logic
+- `src/middleware/auth.ts` — Server-side route protection (runs before pages render)
 
 ---
 
@@ -302,7 +336,7 @@ The token extraction in `extractAccessToken()` handles multiple cookie format va
 ### Roles
 
 | Role | Access | Route Pattern |
-|------|--------|--------------|
+|------|--------|--------------| 
 | `admin` | Full system access | `/admin/*` |
 | `teacher` | Course management, grading | `/teacher/*` |
 | `student` | Dashboard, coursework | `/dashboard`, `/assignments/*` |
@@ -522,7 +556,7 @@ if (!data) {
 ### Component Organization
 
 | Directory | Purpose | Examples |
-|-----------|---------|---------|
+|-----------|---------|---------| 
 | `components/student/` | Student dashboard widgets | `AIKeyWidget`, `AssignmentCard`, `SubmissionStatus` |
 | `components/teacher/` | Teacher grading/creation tools | `AssignmentGrader`, `SubmissionsList` |
 | `components/course/` | Course display | `CourseCard`, `LessonNav`, `VideoPlayer` |
@@ -556,7 +590,7 @@ Authentication is automatic via cookies — the browser sends `sb-*-auth-token` 
 ### Required Variables
 
 | Variable | Scope | Purpose |
-|----------|-------|---------|
+|----------|-------|---------| 
 | `PUBLIC_SUPABASE_URL` | Client + Server | Supabase project URL |
 | `PUBLIC_SUPABASE_ANON_KEY` | Client + Server | Supabase anon key (RLS-enforced) |
 | `SUPABASE_SERVICE_ROLE_KEY` | Server only | Supabase admin key (bypasses RLS) |
@@ -566,9 +600,9 @@ Authentication is automatic via cookies — the browser sends `sb-*-auth-token` 
 ### Optional Variables
 
 | Variable | Scope | Purpose |
-|----------|-------|---------|
-| `OPENROUTER_PROVISIONING_API_KEY` | Server only | OpenRouter Management API key |
-| `PUBLIC_OPENROUTER_STUDENT_WEEKLY_LIMIT` | Client + Server | Weekly spending limit (default: $10) |
+|----------|-------|---------| 
+| `OPENROUTER_MANAGEMENT_KEY` | Server only | OpenRouter Management API key |
+| `OPENROUTER_STUDENT_WEEKLY_LIMIT` | Client + Server | Weekly spending limit (default: $10) |
 | `OPENROUTER_REGEN_COOLDOWN_HOURS` | Server only | Key regen cooldown (default: 24h) |
 | `CRON_SECRET` | Server only | Auth token for cron endpoints |
 | `PUBLIC_STRIPE_*` / `STRIPE_*` | Mixed | Stripe payment integration |
@@ -581,7 +615,7 @@ Authentication is automatic via cookies — the browser sends `sb-*-auth-token` 
 
 ### Graceful Degradation
 
-Optional features return `503` when their env vars are missing (e.g., AI endpoints without `OPENROUTER_PROVISIONING_API_KEY`). The UI components check for 503 and hide themselves (`return null`).
+Optional features return `503` when their env vars are missing (e.g., AI endpoints without `OPENROUTER_MANAGEMENT_KEY`). The UI components check for 503 and hide themselves (`return null`).
 
 ---
 
@@ -623,6 +657,16 @@ npx playwright test       # Run E2E tests
 - Location: `tests/security/`
 - Tests: File upload validation, malware scanning
 
+### Persona-Based QA (Three Required Personas)
+
+When doing browser QA, test from each of these three perspectives (defined in `playwright.personas.yaml`):
+
+1. **Prospective bootcamp student (India)** — Found the site via university outreach. Can they understand what Code for Compassion is, find the application process, and apply in under 5 minutes on a mid-range device?
+2. **Developer evaluating the Guild** — Already has coding skills, looking for a community project. Can they understand the Guild structure, quest system, and progression without clicking into the platform?
+3. **Teacher or org admin reviewing C4C** — Evaluating C4C as a training program for their staff. Can they find curriculum details, cohort structure, and contact information?
+
+For each persona: test the critical flow, verify both light and dark mode rendering, check accessibility (keyboard navigation, contrast, screen reader labels). Run Playwright tests sequentially — never share browser instances between parallel runs.
+
 ### Pre-Commit Hooks (Husky)
 
 - **Schema-types sync** (`npm run db:types:check`) — **Blocking**: commit fails if types don't match schema
@@ -635,7 +679,7 @@ npx playwright test       # Run E2E tests
 ### Naming
 
 | Context | Convention | Example |
-|---------|-----------|---------|
+|---------|-----------|---------| 
 | React components | PascalCase | `AIKeyWidget.tsx`, `CourseCard.tsx` |
 | Utility files | kebab-case | `api-handlers.ts`, `time-gating.ts` |
 | Functions/variables | camelCase | `fetchStatus()`, `handleRefresh()` |
@@ -715,7 +759,57 @@ if (!data) { /* handle */ }
 
 ---
 
-## 14. Security Considerations
+## 14. Safe vs. Risky Changes
+
+### Safe — low blast radius
+
+- Adding new public-facing `.astro` pages (programs, tracks, informational content)
+- Updating copy in existing public pages (text, headings, descriptions)
+- Adding new React components that are self-contained with local state
+- Adding new API endpoints (follow the standard pattern in Section 7)
+- Updating email templates (`src/lib/email-notifications.ts`)
+- Adding unit tests or integration tests
+- Updating CSS custom properties or Tailwind utility class usage
+- Adding or updating blog posts via the blog API
+
+### Moderate — test carefully
+
+- Modifying existing API endpoints — check all callers; `data` shape changes break React components
+- Changing middleware chain order (`src/middleware/index.ts`) — order is performance-critical
+- Updating `src/lib/auth.ts` — affects every authenticated route and API endpoint
+- Changing quiz grading logic (`src/lib/quiz-grading.ts`) — affects existing attempt scores
+- Modifying time-gating logic (`src/lib/time-gating.ts`) — controls what students can access
+- Adding or changing shared React components used across multiple pages
+
+### Risky — do not change without explicit instruction
+
+- **`schema.sql`** — immutable; never change
+- **`src/types/generated.ts`** — auto-generated; never edit by hand
+- **`src/middleware/auth.ts`** — route protection; regressions unlock unauthorized access
+- **`src/lib/security.ts`** — CSRF and XSS prevention; regressions create vulnerabilities
+- **Assignment submission state machine** (`src/lib/assignment-status.ts`) — enrolled students have live submissions
+- **Supabase RLS policies** (in `schema.sql`) — access control at the DB level
+- **Enrollment logic** (`enroll_in_cohort` DB function) — atomic; race conditions possible if changed
+- **Certificate generation** — involves PDF output sent to students
+
+---
+
+## 15. Integration Points
+
+| Integration | Config location | Notes |
+|-------------|----------------|-------|
+| Supabase | `src/lib/supabase.ts`, env vars | Two client patterns — see Section 6 |
+| Vercel | `astro.config.mjs`, `vercel.json` | SSR adapter + cron + security headers |
+| Resend email | `src/lib/email-notifications.ts` | Triggered by enrollment, grading, announcements |
+| OpenRouter | `src/lib/openrouter.ts`, `src/pages/api/ai/` | Optional; degrades to 503 if key absent |
+| Stripe | `src/components/payments/`, `src/pages/api/` | Optional; payment UI hidden if keys absent |
+| Plyr video | `src/components/course/` | Client-side only; embedded in lesson pages |
+| Tiptap editor | `src/components/` | Rich text for assignment submissions and course creation |
+| D3 / Chart.js | `src/components/analytics/` | Dashboard visualizations for teachers and admins |
+
+---
+
+## 16. Security Considerations
 
 - **Never expose `SUPABASE_SERVICE_ROLE_KEY`** in client-side code
 - **Always verify JWT** before using service role client in API routes
@@ -725,14 +819,27 @@ if (!data) { /* handle */ }
 - **CSP headers** are set in middleware — update if adding new external script/style sources
 - **Rate limiting** exists at both client and server levels
 - **RLS policies** are the primary access control mechanism — service role bypasses them, so extra care is needed in API routes
+- **Applications table** stores personal data from prospective students — Supabase RLS must remain enforced on this table
 
 ---
 
-## 15. Deployment
+## 17. Deployment
 
 - **Platform:** Vercel with SSR adapter
 - **Build:** `npm run build` (Astro build with Vercel adapter)
 - **Preview:** `npm run preview` (local production-like server)
 - **Dev:** `npm run dev` (Astro dev server with HMR)
 - **Cron jobs:** Vercel cron calls `/api/cron/*` endpoints with `CRON_SECRET` authentication
+- **Cron schedule:** `/api/cron/module-unlock-notifications` runs daily at 06:00 UTC (`vercel.json`)
 - **Environment:** All server-only env vars are set in Vercel dashboard; `PUBLIC_*` vars are embedded at build time
+
+---
+
+## 18. TODOs and Known Gaps
+
+- **LMS content for May cohort is unassigned** — this is a launch blocker. Assign a content owner or escalate before April 15 (see strategy repo `roadmap/flywheel.md`)
+- **Graze-CLI integration** — pending smoke test on a non-core-team machine before adding to curriculum
+- **No-animal-violence tooling in developer onboarding** — pending curriculum decision
+- **Internationalization** — planned but not started; do not bake in English-only assumptions
+- **Static page performance** — public marketing pages (index, programs, tracks) render server-side on every request; caching strategy TBD
+- **Server-side rate limiting** uses in-memory stores — resets on every Vercel cold start; consider Redis for persistent rate limiting at scale

--- a/readme.md
+++ b/readme.md
@@ -2,17 +2,25 @@
 
 **Engineering Compassion Through AI**
 
-C4C Campus is a learning platform that trains developers to build AI tools for animal advocacy, climate action, and AI safety. Based in Bengaluru with remote participation worldwide.
+> Status: **Active Development** — Hard deadline: May 2026 Resident Developer cohort launch. The platform is predominantly working; contributors should expect active feature work alongside ongoing bug fixes.
 
-## What We Do
+C4C Campus is a full-featured Learning Management System (LMS) for [Code for Compassion](https://codeforcompassion.com) — a training program that equips developers to build AI tools for animal advocacy, climate action, and AI safety. Based in Bengaluru with remote participation worldwide.
 
-We run three programs to build technical capacity in impact movements:
+This repository is part of the [Open Paws](https://openpaws.ai) ecosystem — infrastructure for the animal liberation movement.
 
-- **Weekend Bootcamp** - 12 weeks, no technical skills required. Learn no-code/low-code AI development.
-- **Global Hackathons** - Build prototype tools and find your team.
-- **Full-Time Accelerator** - 12 weeks intensive. Take your prototype to production.
+---
 
-## Three Focus Areas
+## What is Code for Compassion?
+
+Code for Compassion runs three programs to build technical capacity in impact movements:
+
+| Program | Format | Who It's For |
+|---------|--------|-------------|
+| **Weekend Bootcamp** | 12 weeks, no coding required | Activists who want to build no-code/low-code AI tools |
+| **Global Hackathons** | Intensive sprint | Developers who want to prototype advocacy tools and find a team |
+| **Full-Time Accelerator** | 12 weeks intensive | Developers taking a prototype to production |
+
+### Three Focus Tracks
 
 | Animal Advocacy | Climate Action | AI Safety |
 |-----------------|----------------|-----------|
@@ -20,121 +28,344 @@ We run three programs to build technical capacity in impact movements:
 | Rescue coordination | Renewable energy optimization | Adversarial defense |
 | Campaign automation | Climate litigation support | Ethics testing |
 
-## Platform Features
+---
 
-This codebase powers the C4C Campus learning management system:
+## What This Codebase Does
 
-- **Student Experience** - Course progress, assignments, quizzes, certificates
-- **Teacher Tools** - Course creation, cohort management, grading, analytics
-- **Admin Portal** - Application review, user management, platform settings
-- **Discussion Forums** - Course-specific discussions with moderation
+This repo is the public-facing website **and** the LMS backend — the same codebase powers both the recruitment funnel and the enrolled student experience:
+
+**Public pages** (recruitment funnel):
+- Home, About, Programs, Tracks, Framework, FAQ, Pricing
+- Apply (application form with Supabase storage)
+- Blog
+
+**Authenticated LMS** (enrolled students, teachers, admins):
+- Student dashboard with cohort progress, AI key widget, notifications
+- Course browsing and lesson delivery (video via Plyr, rich text via Tiptap)
+- Assignments: submission, grading, rubrics
+- Quizzes: auto-graded, multiple question types
+- Discussion forums per lesson and per course
+- Certificates with PDF generation
+- Teacher portal: course creation, cohort management, grading, analytics
+- Admin portal: application review, user management, platform stats
+- OpenRouter AI key provisioning per student (weekly spending limit enforced)
+- Stripe payment integration (optional)
+
+---
 
 ## Tech Stack
 
-- [Astro](https://astro.build) + React
-- [Supabase](https://supabase.com) (PostgreSQL, Auth, Storage)
-- [Tailwind CSS](https://tailwindcss.com)
-- [Resend](https://resend.com) (Email)
-- [Vercel](https://vercel.com) (Hosting)
+| Layer | Technology |
+|-------|-----------|
+| Framework | [Astro 6](https://astro.build) — SSR only (no static generation) |
+| UI islands | [React 19](https://react.dev) (`client:only="react"` or `client:load`) |
+| Styling | [Tailwind CSS v4](https://tailwindcss.com) with CSS custom property design system |
+| Database | [Supabase](https://supabase.com) (PostgreSQL + Auth + Storage + Realtime) |
+| Auth | Supabase Auth + independent JWT verification via [`jose`](https://github.com/panva/jose) / JWKS |
+| Email | [Resend](https://resend.com) |
+| Hosting | [Vercel](https://vercel.com) (serverless SSR + cron jobs) |
+| Payments | [Stripe](https://stripe.com) (optional) |
+| AI features | [OpenRouter](https://openrouter.ai) Management API (per-student key provisioning) |
+| Testing | [Vitest](https://vitest.dev) (unit + integration) + [Playwright](https://playwright.dev) (E2E) |
 
-## Quick Start
+### Key architectural decisions
+
+- **SSR-only** — every page renders on Vercel serverless functions; no static output
+- **Islands architecture** — `.astro` files handle layout and server data fetching; React `.tsx` islands handle interactivity
+- **Database-driven content** — courses, modules, lessons, and cohort schedules live in Supabase, not in Astro content collections
+- **Schema is immutable** — `schema.sql` is the single source of truth; TypeScript types must conform to it, never the reverse
+- **Two Supabase client patterns** — anon key (RLS enforced, client-safe) and service role key (RLS bypassed, server API routes only, always after JWT verification)
+
+---
+
+## Local Development Setup
+
+### Prerequisites
+
+- Node.js >= 22.12.0 (see `package.json` `engines` field)
+- npm 10.x
+- A Supabase project (free tier works)
+- A Resend account for email (free tier works)
+
+### 1. Clone and install
 
 ```bash
 git clone https://github.com/Open-Paws/c4c-campus-website.git
 cd c4c-campus-website
 npm install
-cp .env.example .env  # Fill in your credentials
-npm run dev
 ```
 
-### Environment Variables
+### 2. Configure environment
+
+```bash
+cp .env.example .env
+```
+
+Fill in `.env` — minimum required:
 
 ```env
 PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 RESEND_API_KEY=re_your_api_key
-SITE_URL=https://your-domain.com
+SITE_URL=http://localhost:4321
+NODE_ENV=development
 ```
 
-### Database Setup
-`schema.sql` is everything. Single command:
+Find `PUBLIC_SUPABASE_URL` and keys at **Supabase dashboard → Settings → API**.
+
+### 3. Apply the database schema
 
 ```bash
-npm run db:schema-apply  # Backup + destructive reset + validate
+# Requires DATABASE_URL set in .env (Supabase → Project Settings → Database → Connection string → URI)
+npm run db:schema-apply   # backup → destructive reset → validate
 ```
 
-See [docs/DATABASE.md](docs/DATABASE.md) for details/troubleshooting.
+See [`docs/DATABASE.md`](docs/DATABASE.md) for detailed schema management, troubleshooting, and the incremental migration workflow.
 
-### Schema-TypeScript Sync Process
-
-**IMPORTANT:** The database schema (`schema.sql`) is the single source of truth. TypeScript types must always match the schema. See [docs/DATABASE.md](docs/DATABASE.md) for detailed schema management workflows.
-
-#### When Modifying the Database Schema:
-
-1. Update `schema.sql` with your changes
-2. Update corresponding TypeScript types:
-   - `src/types/index.ts` - Core types (Enrollment, Course, Module, Lesson, Cohort, etc.)
-   - `src/types/quiz.ts` - Quiz system types (Quiz, QuizAttempt, QuizQuestion, etc.)
-   - `src/types/assignment.ts` - Assignment types (Assignment, Submission, etc.)
-3. Update any API handlers that reference modified columns
-4. Run TypeScript compilation to catch type errors: `npx astro check`
-5. Update integration tests to verify new schema fields
-
-#### Key Conventions:
-
-- **UUIDs**: All `id` fields on tables like `cohorts`, `quiz_attempts`, `assignment_submissions` are UUID strings, not numbers
-- **Nullable fields**: Match DB `NULL` with TypeScript `| null`
-- **JSONB columns**: Define typed interfaces (e.g., `CohortProgress` for `cohort_enrollments.progress`)
-- **CHECK constraints**: TypeScript union types must match DB constraints exactly (e.g., `QuestionType`, `GradingStatus`)
-- **Column renames**: If the DB column name differs from the TypeScript property, add a comment noting the mapping
-
-#### Type Generation and CI:
-
-The project includes automated schema-types synchronization:
+### 4. Run the dev server
 
 ```bash
-# Generate types from local schema (requires Supabase CLI)
-npm run db:types
-
-# Manually check schema-types synchronization
-npm run db:types:check
+npm run dev
 ```
 
-A GitHub Actions workflow (`.github/workflows/schema-types-check.yml`) automatically runs on every push or PR that modifies `schema.sql` or `src/types/**`. The CI will fail if:
-- TypeScript types don't match the database schema
-- UUID fields are incorrectly typed as `number` instead of `string`
-- Known schema mismatches are detected (e.g., `time_limit` vs `time_limit_minutes`)
+Open `http://localhost:4321`.
 
-To fix schema-type issues:
-1. Run `npm run db:types:check` to identify problems
-2. Update types in `src/types/` to match `schema.sql`
-3. Ensure all ID fields use `string` type (UUIDs)
-4. Run `npx astro check` to verify no TypeScript errors
+---
 
-#### Workflow for Contributors
+## Configuration Reference
 
-**IMPORTANT:** Do NOT hand-edit `src/types/generated.ts`. This file is auto-generated from the database schema.
+All environment variables are documented in `.env.example`. Summary:
 
-When making schema changes:
-1. Modify `schema.sql` with your changes
-2. Run `npm run db:types` to regenerate `src/types/generated.ts`
-3. Commit BOTH `schema.sql` and `src/types/generated.ts` together
-4. The CI will fail if generated.ts is out of sync
+### Required
 
-The helper type aliases at the bottom of `generated.ts` (like `QuizRow`, `AssignmentRow`) may be manually maintained, but the `Database` type definition must remain auto-generated.
+| Variable | Scope | Purpose |
+|----------|-------|---------|
+| `PUBLIC_SUPABASE_URL` | Client + Server | Supabase project URL |
+| `PUBLIC_SUPABASE_ANON_KEY` | Client + Server | Anon key — RLS enforced |
+| `SUPABASE_SERVICE_ROLE_KEY` | Server only | Admin key — bypasses RLS; never expose to client |
+| `RESEND_API_KEY` | Server only | Transactional email |
+| `SITE_URL` | Server | Canonical URL (used in email links, CORS, auth redirects) |
 
-Consider adding a pre-commit hook to catch drift early:
+### Optional
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `OPENROUTER_MANAGEMENT_KEY` | — | Per-student AI key provisioning; feature hidden if absent |
+| `OPENROUTER_STUDENT_WEEKLY_LIMIT` | `10` | USD weekly spend cap per student |
+| `OPENROUTER_REGEN_COOLDOWN_HOURS` | `24` | Hours between key regenerations |
+| `CRON_SECRET` | — | Auth token for Vercel cron calls to `/api/cron/*` |
+| `PUBLIC_STRIPE_PUBLISHABLE_KEY` | — | Stripe client key; payment UI hidden if absent |
+| `STRIPE_SECRET_KEY` | — | Stripe server key |
+| `STRIPE_WEBHOOK_SECRET` | — | Stripe webhook verification |
+| `DATABASE_URL` | — | Direct PostgreSQL URI — local dev scripts only, never Vercel |
+
+**Naming convention:** variables prefixed `PUBLIC_` are embedded in client bundles at build time. All others are server-only.
+
+---
+
+## Available Scripts
+
 ```bash
-# In your local tooling configuration, run this when schema.sql or src/types/ change:
-npm run db:types:check
+# Development
+npm run dev               # Astro dev server with hot reload (port 4321)
+npm run build             # Production build
+npm run build:production  # Image optimization + type check + build
+npm run preview           # Preview production build locally
+
+# Type checking
+npm run check             # astro check (TypeScript + template types)
+
+# Testing
+npm run test              # Vitest unit tests (fast, jsdom)
+npm run test:watch        # Vitest in watch mode
+npm run test:coverage     # Unit test coverage report
+npm run test:integration  # Integration tests against real Supabase DB (sequential)
+
+# Database
+npm run db:types          # Regenerate src/types/generated.ts from local schema
+npm run db:types:check    # Verify generated types match schema
+npm run db:validate:all   # Run all schema validation checks
+npm run db:schema-apply   # Backup → destructive reset → validate (DESTRUCTIVE)
+
+# Quality
+npx astro check           # TypeScript type checking
 ```
+
+---
+
+## Project Structure
+
+```
+c4c-campus-website/
+├── schema.sql              # IMMUTABLE database schema — source of truth
+├── astro.config.mjs        # Astro + Vercel SSR config
+├── vercel.json             # Security headers + cron schedule
+├── .env.example            # All environment variables documented
+├── src/
+│   ├── middleware/         # Request pipeline: perf → CORS → auth → cache → security
+│   ├── lib/                # Shared server/client utilities (auth, Supabase, rate limiting…)
+│   ├── types/
+│   │   ├── generated.ts    # AUTO-GENERATED — never edit by hand
+│   │   └── index.ts        # Application-level types extending generated
+│   ├── pages/
+│   │   ├── index.astro     # Home
+│   │   ├── apply.astro     # Application form
+│   │   ├── dashboard.astro # Student dashboard (auth required)
+│   │   ├── courses/        # Course browsing + lesson delivery
+│   │   ├── assignments/    # Assignment submission
+│   │   ├── quizzes/        # Quiz delivery
+│   │   ├── teacher/        # Teacher portal
+│   │   ├── admin/          # Admin portal
+│   │   └── api/            # 40+ API endpoints (Astro file-based routing)
+│   ├── components/
+│   │   ├── student/        # Student dashboard widgets (React islands)
+│   │   ├── teacher/        # Teacher grading/creation tools
+│   │   ├── course/         # Course display components
+│   │   ├── analytics/      # D3/Chart.js data visualizations
+│   │   ├── search/         # Search UI
+│   │   ├── certificates/   # Certificate generation
+│   │   └── payments/       # Stripe integration
+│   ├── layouts/            # Astro layout templates
+│   └── styles/             # Global CSS + Tailwind base
+├── tests/
+│   ├── unit/               # Vitest + jsdom
+│   ├── integration/        # Vitest + real Supabase DB
+│   ├── e2e/                # Playwright (6 browser/device configurations)
+│   └── security/           # File upload validation, malware scanning
+├── migrations/             # Incremental SQL migrations
+├── scripts/                # DB validation, type generation, maintenance
+└── docs/                   # Extended documentation
+```
+
+---
+
+## Database Architecture
+
+The schema (`schema.sql`) defines **34 tables** across these domains:
+
+- **Auth & profiles:** `applications`, `profiles`, `auth_logs`
+- **Course structure:** `courses`, `modules`, `lessons`
+- **Cohort system:** `cohorts`, `cohort_enrollments`, `cohort_schedules`, `enrollments`, `lesson_progress`
+- **Discussions:** `lesson_discussions`, `course_forums`, `forum_replies`
+- **Assessments:** `quizzes`, `quiz_questions`, `quiz_attempts`, `assignments`, `assignment_rubrics`, `assignment_submissions`
+- **Messaging:** `message_threads`, `messages`, `notifications`, `announcements`
+- **AI assistant:** `ai_conversations`, `ai_messages`, `ai_usage_logs`
+- **Certificates:** `certificates`, `certificate_templates`
+- **Payments:** `payments`, `subscriptions`
+- **Media & analytics:** `media_library`, `analytics_events`
+
+### Critical: ID types
+
+| ID type | Tables | TypeScript |
+|---------|--------|-----------|
+| UUID (string) | `cohorts`, `quiz_attempts`, `assignment_submissions`, `applications`, most junction tables | `string` |
+| BIGSERIAL (number) | `courses`, `modules`, `lessons`, `enrollments`, `lesson_progress` | `number` |
+
+Confusing these causes silent runtime failures. Always check `schema.sql` before writing query code.
+
+### Schema-TypeScript sync
+
+`src/types/generated.ts` is auto-generated and must never be edited manually. When you change `schema.sql`:
+
+1. Run `npm run db:types` to regenerate `src/types/generated.ts`
+2. Update hand-maintained types in `src/types/index.ts` as needed
+3. Run `npm run db:validate:all` to catch drift
+4. Commit `schema.sql` and `src/types/generated.ts` together
+
+A GitHub Actions workflow fails CI when generated types drift from the schema.
+
+---
+
+## Authentication
+
+Authentication uses a two-layer approach:
+
+1. **Supabase Auth** handles registration, login, password reset, and sessions
+2. **Server-side JWT verification** via `jose` / JWKS (`src/lib/auth.ts`) validates tokens independently
+
+API routes that use the service role key bypass Row Level Security. The `jose`-based check ensures forged tokens cannot reach privileged endpoints.
+
+**Roles:** `admin` (`/admin/*`), `teacher` (`/teacher/*`), `student` (`/dashboard`, `/assignments/*`). Stored in `profiles.role`, enforced by `src/middleware/auth.ts`.
+
+---
 
 ## Deployment
 
-Connect to Vercel and add environment variables. That's it.
+### Vercel (production)
 
-After deploying, update your Supabase project's Site URL to match your domain.
+1. Connect the repo to a Vercel project
+2. Add all required environment variables in the Vercel dashboard
+3. Deploy — the `@astrojs/vercel` adapter handles everything
+
+After first deploy, update your Supabase project's **Site URL** to match your Vercel domain.
+
+**Cron job:** `vercel.json` schedules `/api/cron/module-unlock-notifications` daily at 06:00 UTC. The endpoint requires `CRON_SECRET` in the `Authorization` header.
+
+### Build commands
+
+| Command | Use |
+|---------|-----|
+| `npm run build` | Standard Vercel build |
+| `npm run build:production` | Local production build with image optimization and type check |
+
+---
+
+## Contributing
+
+### Before making any change
+
+1. Read the relevant source files — understand what exists before writing
+2. Check `schema.sql` for exact column names, types, and constraints
+3. Run `npx astro check` to confirm the baseline compiles cleanly
+4. Run `npm run db:validate:all` for schema-code alignment
+
+### Validation checklist before committing
+
+```bash
+npx astro check              # Type check
+npm run db:types:check        # Schema-types sync (blocking pre-commit hook)
+npm run db:field-names:check  # Field naming (non-blocking warning)
+npm run db:validate:all       # All checks
+npm run test:integration      # Integration tests
+```
+
+### Critical rules
+
+- **Never modify `schema.sql`** — it is immutable. All code must adapt to the schema, not the reverse
+- **Never edit `src/types/generated.ts` by hand** — always regenerate via `npm run db:types`
+- **Never expose `SUPABASE_SERVICE_ROLE_KEY`** in client-side code
+- **Always verify JWT** before using the service role client in API routes
+- **Use snake_case in all database queries** — `.select('user_id')`, never `.select('userId')`
+- **Don't refactor while fixing bugs** — stay focused; scope creep causes regressions
+
+### Language and domain standards
+
+This is software for the animal liberation movement. All code, comments, commit messages, and documentation must:
+
+- Use movement terminology precisely: **campaign**, **investigation**, **activist**, **farmed animal**, **factory farm**, **slaughterhouse**, **direct action**
+- Use **farmed animal/s** — never industry commodity framing
+- Avoid speciesist idioms (60+ patterns enforced by the [no-animal-violence](https://github.com/Open-Paws/no-animal-violence) tooling suite)
+- Run `semgrep --config semgrep-no-animal-violence.yaml` on all code/docs edits
+
+### Quality gates
+
+- **Desloppify score:** `desloppify scan --path .` — minimum ≥85
+- **TypeScript:** zero errors from `npx astro check` before pushing
+- **Schema:** `npm run db:validate:all` must pass before any commit touching DB code
+
+---
+
+## Accessibility
+
+C4C Campus is the India recruitment funnel for a movement. Accessibility is not optional:
+
+- Must work on low-end Android devices and 3G connections
+- Screen reader navigation, keyboard-only flows, and sufficient color contrast are requirements
+- Internationalization is planned — do not bake in English-only assumptions
+- Progressive disclosure applies to any advocacy content with strong imagery or statistics
+
+---
 
 ## License
 


### PR DESCRIPTION
## Summary

- **README rewrite** — expanded from 5KB to ~16KB; now covers what C4C Campus is and who it's for, the full tech stack, local dev setup with prerequisites, complete environment variable reference, available scripts, project structure, database architecture (including the critical ID type distinction), auth overview, deployment, and a contributing guide with quality gates and domain language requirements
- **AGENTS.md update** — added Section 0 (organizational context, current status, strategy fetch commands, May 2026 deadline, known blockers), Section 14 (safe vs. risky change classification), Section 15 (integration points table), Section 18 (TODOs and known gaps); added three-persona QA framework to the testing section; preserved all existing content

## What changed and why

The existing `readme.md` was accurate but sparse — it left key questions unanswered for a new contributor: how auth works, how to handle the dual Supabase client pattern, what the ID type distinction is, what's safe to change vs. risky. The existing `AGENTS.md` was already strong but was missing the organizational context from `CLAUDE.md` (current status, launch timeline, blockers) and lacked a safe-vs-risky guide to help agents prioritize carefully.

## Test plan

- [ ] README renders correctly on GitHub (headings, tables, code blocks)
- [ ] AGENTS.md renders correctly on GitHub
- [ ] No broken internal links (all paths reference files that exist)
- [ ] No speciesist idioms in either file
- [ ] Content is accurate against the actual codebase state
